### PR TITLE
Fix Enzyme extension and add new broken test

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,9 +21,9 @@ ImplicitDifferentiationEnzymeExt = "Enzyme"
 ImplicitDifferentiationForwardDiffExt = "ForwardDiff"
 
 [compat]
-ADTypes = "1.0"
+ADTypes = "1.7.1"
 ChainRulesCore = "1.23.0"
-DifferentiationInterface = "0.5"
+DifferentiationInterface = "0.5.12"
 Enzyme = "0.11.20,0.12"
 ForwardDiff = "0.10.36"
 Krylov = "0.9.5"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ImplicitDifferentiation"
 uuid = "57b37032-215b-411a-8a7c-41a003a55207"
 authors = ["Guillaume Dalle", "Mohamed Tarek and contributors"]
-version = "0.6.0"
+version = "0.6.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/examples/3_tricks.jl
+++ b/examples/3_tricks.jl
@@ -68,7 +68,7 @@ J = ForwardDiff.jacobian(forward_components, x)  #src
 Zygote.jacobian(implicit_components, x)[1]
 @test Zygote.jacobian(implicit_components, x)[1] ≈ J  #src
 
-@test Enzyme.jacobian(Enzyme.Forward, implicit_components, x) ≈ J  #src
+# @test Enzyme.jacobian(Enzyme.Forward, implicit_components, x) ≈ J  #src
 
 #- The full differentiable pipeline looks like this
 

--- a/examples/3_tricks.jl
+++ b/examples/3_tricks.jl
@@ -68,7 +68,7 @@ J = ForwardDiff.jacobian(forward_components, x)  #src
 Zygote.jacobian(implicit_components, x)[1]
 @test Zygote.jacobian(implicit_components, x)[1] ≈ J  #src
 
-# @test Enzyme.jacobian(Enzyme.Forward, implicit_components, x) ≈ J  #src
+@test_broken Enzyme.jacobian(Enzyme.Forward, implicit_components, x) ≈ J  #src
 
 #- The full differentiable pipeline looks like this
 

--- a/examples/3_tricks.jl
+++ b/examples/3_tricks.jl
@@ -5,6 +5,7 @@ We demonstrate several features that may come in handy for some users.
 =#
 
 using ComponentArrays
+using Enzyme  #src
 using ForwardDiff
 using ImplicitDifferentiation
 using Krylov
@@ -66,6 +67,8 @@ J = ForwardDiff.jacobian(forward_components, x)  #src
 
 Zygote.jacobian(implicit_components, x)[1]
 @test Zygote.jacobian(implicit_components, x)[1] ≈ J  #src
+
+@test Enzyme.jacobian(Enzyme.Forward, implicit_components, x) ≈ J  #src
 
 #- The full differentiable pipeline looks like this
 

--- a/ext/ImplicitDifferentiationEnzymeExt.jl
+++ b/ext/ImplicitDifferentiationEnzymeExt.jl
@@ -5,6 +5,10 @@ using Enzyme
 using Enzyme.EnzymeCore
 using ImplicitDifferentiation: ImplicitFunction, build_A, build_B, byproduct, output
 
+const FORWARD_BACKEND = AutoEnzyme(;
+    mode=Enzyme.Forward, function_annotation=Enzyme.Duplicated
+)
+
 function EnzymeRules.forward(
     func::Const{<:ImplicitFunction},
     RT::Type{<:Union{BatchDuplicated,BatchDuplicatedNoNeed}},
@@ -20,7 +24,7 @@ function EnzymeRules.forward(
     y = output(y_or_yz)
     Y = typeof(y)
 
-    suggested_backend = AutoEnzyme(Enzyme.Forward)
+    suggested_backend = FORWARD_BACKEND
     A = build_A(implicit, x, y_or_yz, args...; suggested_backend)
     B = build_B(implicit, x, y_or_yz, args...; suggested_backend)
 

--- a/ext/ImplicitDifferentiationEnzymeExt.jl
+++ b/ext/ImplicitDifferentiationEnzymeExt.jl
@@ -5,7 +5,7 @@ using Enzyme
 using Enzyme.EnzymeCore
 using ImplicitDifferentiation: ImplicitFunction, build_A, build_B, byproduct, output
 
-const FORWARD_BACKEND = AutoEnzyme(; mode=Enzyme.Forward)
+const FORWARD_BACKEND = AutoEnzyme(; mode=Enzyme.Forward, function_annotation=Enzyme.Const)
 
 function EnzymeRules.forward(
     func::Const{<:ImplicitFunction},

--- a/ext/ImplicitDifferentiationEnzymeExt.jl
+++ b/ext/ImplicitDifferentiationEnzymeExt.jl
@@ -5,9 +5,7 @@ using Enzyme
 using Enzyme.EnzymeCore
 using ImplicitDifferentiation: ImplicitFunction, build_A, build_B, byproduct, output
 
-const FORWARD_BACKEND = AutoEnzyme(;
-    mode=Enzyme.Forward, function_annotation=Enzyme.Duplicated
-)
+const FORWARD_BACKEND = AutoEnzyme(; mode=Enzyme.Forward)
 
 function EnzymeRules.forward(
     func::Const{<:ImplicitFunction},

--- a/ext/ImplicitDifferentiationEnzymeExt.jl
+++ b/ext/ImplicitDifferentiationEnzymeExt.jl
@@ -24,8 +24,7 @@ function EnzymeRules.forward(
     A = build_A(implicit, x, y_or_yz, args...; suggested_backend)
     B = build_B(implicit, x, y_or_yz, args...; suggested_backend)
 
-    dx_batch = reduce(hcat, dx)
-    dc_batch = mapreduce(hcat, eachcol(dx_batch)) do dₖx
+    dc_batch = mapreduce(hcat, dx) do dₖx
         B * dₖx
     end
     dy_batch = implicit.linear_solver(A, -dc_batch)

--- a/test/systematic.jl
+++ b/test/systematic.jl
@@ -12,7 +12,7 @@ include("utils.jl")
 
 backends = [
     AutoForwardDiff(; chunksize=1), #
-    AutoEnzyme(; mode=Enzyme.Forward),
+    AutoEnzyme(; mode=Enzyme.Forward, function_annotation=Enzyme.Const),
     AutoZygote(),
 ]
 
@@ -24,7 +24,7 @@ linear_solver_candidates = (
 conditions_backend_candidates = (
     nothing, #
     AutoForwardDiff(; chunksize=1),
-    AutoEnzyme(; mode=Enzyme.Forward),
+    AutoEnzyme(; mode=Enzyme.Forward, function_annotation=Enzyme.Const),
 );
 
 x_candidates = (

--- a/test/systematic.jl
+++ b/test/systematic.jl
@@ -24,7 +24,7 @@ linear_solver_candidates = (
 conditions_backend_candidates = (
     nothing, #
     AutoForwardDiff(; chunksize=1),
-    AutoEnzyme(Enzyme.Forward),
+    AutoEnzyme(; mode=Enzyme.Forward),
 );
 
 x_candidates = (

--- a/test/systematic.jl
+++ b/test/systematic.jl
@@ -12,7 +12,7 @@ include("utils.jl")
 
 backends = [
     AutoForwardDiff(; chunksize=1), #
-    AutoEnzyme(Enzyme.Forward),
+    AutoEnzyme(; mode=Enzyme.Forward),
     AutoZygote(),
 ]
 


### PR DESCRIPTION
- Bump version to v0.6.1
- Fix Enzyme extension to work with the latest version of `ADTypes.AutoEnzyme`. Assume that `conditions` doesn't need to be `Duplicated`
- Add new broken test for ComponentArrays (see #150)