### PR TITLE
Make Krylov solver verbose and public

### DIFF
--- a/src/ImplicitDifferentiation.jl
+++ b/src/ImplicitDifferentiation.jl
@@ -23,6 +23,6 @@ using LinearAlgebra: axpby!, factorize, lu
 include("implicit_function.jl")
 include("operators.jl")
 
-export ImplicitFunction
+export ImplicitFunction, KrylovLinearSolver
 
 end


### PR DESCRIPTION
- Make `KrylovLinearSolver` part of the public API
- Add `verbose` keyword to `KrylovLinearSolver` which throws warning when `!stats.solved || stats.inconsistent` (ping @benjaminfaber who ran into related issues on [Discourse](https://discourse.julialang.org/t/mismatched-forwarddiff-and-finitedifference-gradients-with-implicitdifferentiation/119756/11?u=gdalle))
- Merge docstrings

Related:
- https://github.com/JuliaSmoothOptimizers/Krylov.jl/issues/876