### PR TITLE
test!: better tests

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -19,13 +19,9 @@ ImplicitFunction
 ### Settings
 
 ```@docs
-IterativeLinearSolver
 MatrixRepresentation
 OperatorRepresentation
-NoPreparation
-ForwardPreparation
-ReversePreparation
-BothPreparation
+IterativeLinearSolver
 ```
 
 ## Internals

--- a/src/ImplicitDifferentiation.jl
+++ b/src/ImplicitDifferentiation.jl
@@ -33,9 +33,8 @@ include("preparation.jl")
 include("implicit_function.jl")
 include("execution.jl")
 
-export IterativeLinearSolver
 export MatrixRepresentation, OperatorRepresentation
-export NoPreparation, ForwardPreparation, ReversePreparation, BothPreparation
+export IterativeLinearSolver
 export ImplicitFunction
 
 end

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -1,15 +1,15 @@
-@testitem "intro" begin
+@testitem "Intro" begin
     include(joinpath(dirname(@__DIR__), "examples", "0_intro.jl"))
 end
 
-@testitem "basic" begin
+@testitem "Basic" begin
     include(joinpath(dirname(@__DIR__), "examples", "1_basic.jl"))
 end
 
-@testitem "advanced" begin
+@testitem "Advanced" begin
     include(joinpath(dirname(@__DIR__), "examples", "2_advanced.jl"))
 end
 
-@testitem "tricks" begin
+@testitem "Tricks" begin
     include(joinpath(dirname(@__DIR__), "examples", "3_tricks.jl"))
 end

--- a/test/formalities.jl
+++ b/test/formalities.jl
@@ -6,16 +6,19 @@ using TestItems
     using Zygote: Zygote
     Aqua.test_all(ImplicitDifferentiation; ambiguities=false, undocumented_names=true)
 end
+
 @testitem "Formatting" begin
     using JuliaFormatter
     @test format(ImplicitDifferentiation; verbose=false, overwrite=false)
 end
+
 @testitem "Static checking" begin
     using JET
     using ForwardDiff: ForwardDiff
     using Zygote: Zygote
     JET.test_package(ImplicitDifferentiation; target_defined_modules=true)
 end
+
 @testitem "Imports" begin
     using ExplicitImports
     using ForwardDiff: ForwardDiff
@@ -27,6 +30,7 @@ end
     @test check_all_qualified_accesses_via_owners(ImplicitDifferentiation) === nothing
     @test check_no_self_qualified_accesses(ImplicitDifferentiation) === nothing
 end
+
 @testitem "Doctests" begin
     using Documenter
     Documenter.DocMeta.setdocmeta!(

--- a/test/preparation.jl
+++ b/test/preparation.jl
@@ -1,0 +1,62 @@
+@testitem "Preparation" begin
+    using ImplicitDifferentiation
+    using ADTypes: AutoForwardDiff, ForwardOrReverseMode, ForwardMode, ReverseMode
+    using ForwardDiff: ForwardDiff
+    using Zygote: Zygote
+    using Test
+
+    solver(x) = sqrt.(x), nothing
+    conditions(x, y, z) = y .^ 2 .- x
+    x = rand(5)
+    input_example = (x,)
+
+    @testset "None" begin
+        implicit_nones = ImplicitFunction(solver, conditions)
+        @test implicit_none.prep_A === nothing
+        @test implicit_none.prep_Aᵀ === nothing
+        @test implicit_none.prep_B === nothing
+        @test implicit_none.prep_Bᵀ === nothing
+    end
+
+    @testset "ForwardMode" begin
+        implicit_forward = ImplicitFunction(
+            solver,
+            conditions;
+            preparation=ForwardMode(),
+            backends=(; x=AutoForwardDiff(), y=AutoForwardDiff()),
+            input_example,
+        )
+        @test implicit_forward.prep_A !== nothing
+        @test implicit_forward.prep_Aᵀ === nothing
+        @test implicit_forward.prep_B !== nothing
+        @test implicit_forward.prep_Bᵀ === nothing
+    end
+
+    @testset "ReverseMode" begin
+        implicit_reverse = ImplicitFunction(
+            solver,
+            conditions;
+            preparation=ReverseMode(),
+            backends=(; x=AutoZygote(), y=AutoZygote()),
+            input_example,
+        )
+        @test implicit_reverse.prep_A === nothing
+        @test implicit_reverse.prep_Aᵀ !== nothing
+        @test implicit_reverse.prep_B === nothing
+        @test implicit_reverse.prep_Bᵀ !== nothing
+    end
+
+    @testset "Both" begin
+        implicit_both = ImplicitFunction(
+            solver,
+            conditions;
+            preparation=ForwardOrReverseMode(),
+            backends=(; x=AutoForwardDiff(), y=AutoZygote()),
+            input_example,
+        )
+        @test implicit_both.prep_A !== nothing
+        @test implicit_both.prep_Aᵀ !== nothing
+        @test implicit_both.prep_B !== nothing
+        @test implicit_both.prep_Bᵀ !== nothing
+    end
+end

--- a/test/preparation.jl
+++ b/test/preparation.jl
@@ -1,6 +1,7 @@
 @testitem "Preparation" begin
     using ImplicitDifferentiation
-    using ADTypes: AutoForwardDiff, ForwardOrReverseMode, ForwardMode, ReverseMode
+    using ADTypes
+    using ADTypes: ForwardOrReverseMode, ForwardMode, ReverseMode
     using ForwardDiff: ForwardDiff
     using Zygote: Zygote
     using Test

--- a/test/preparation.jl
+++ b/test/preparation.jl
@@ -12,7 +12,7 @@
     input_example = (x,)
 
     @testset "None" begin
-        implicit_nones = ImplicitFunction(solver, conditions)
+        implicit_none = ImplicitFunction(solver, conditions)
         @test implicit_none.prep_A === nothing
         @test implicit_none.prep_Aᵀ === nothing
         @test implicit_none.prep_B === nothing

--- a/test/printing.jl
+++ b/test/printing.jl
@@ -1,0 +1,6 @@
+using TestItems
+
+@testitem "Settings" begin
+    @test startswith(string(OperatorRepresentation()), "Operator")
+    @test startswith(string(IterativeLinearSolver(; atol=1e-5)), "Iterative")
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,9 @@
 using TestItemRunner
 
+@testmodule TestUtils begin
+    include("utils.jl")
+    export Scenario, test_implicit, add_arg_mult
+    export default_solver, default_conditions
+end
+
 @run_package_tests

--- a/test/systematic.jl
+++ b/test/systematic.jl
@@ -21,7 +21,6 @@ using TestItems
             ),
         )
         scen2 = add_arg_mult(scen)
-        @info "$scen"
         test_implicit(scen)
         test_implicit(scen2)
     end
@@ -47,7 +46,6 @@ end;
                 input_example=(x,),
             ),
         )
-        @info "$scen"
         scen2 = add_arg_mult(scen)
         test_implicit(scen)
         test_implicit(scen2)
@@ -67,14 +65,13 @@ end;
             conditions=default_conditions,
             x=x,
             implicit_kwargs=(;
-                representation=OperatorRepresentation{:LinearMap}(),
+                representation=OperatorRepresentation{:LinearMaps}(),
                 linear_solver=IterativeLinearSolver{:IterativeSolvers}(),
                 backends,
                 preparation,
                 input_example=(x,),
             ),
         )
-        @info "$scen"
         test_implicit(scen)
     end
 end;


### PR DESCRIPTION
> [!CAUTION]
> Breaking changes

**Breaking changes**

- The argument `backends` to `ImplicitFunction` must now be either `nothing` or a named tuple `(; x, y)` of backends, it can't just be a single backend (because we need to specify how to differentiate the conditions with respect to each argument)
- Remove `Preparation` types from code and docs since they were useless

**Other changes**

- Revamp systematic tests to make them more modular