### PR TITLE
fix: only factorize for direct linear solve

### DIFF
--- a/src/execution.jl
+++ b/src/execution.jl
@@ -46,7 +46,7 @@ end
 function build_A_aux(
     ::MatrixRepresentation, implicit, prep, x, y, z, c, args...; suggested_backend
 )
-    (; conditions, backends) = implicit
+    (; conditions, linear_solver, backends) = implicit
     (; prep_A) = prep
     actual_backend = isnothing(backends) ? suggested_backend : backends.y
     contexts = (Constant(x), Constant(z), map(Constant, args)...)
@@ -56,7 +56,11 @@ function build_A_aux(
     else
         A = jacobian(f, prep_A, actual_backend, y, contexts...)
     end
-    return factorize(A)
+    if linear_solver isa DirectLinearSolver
+        return factorize(A)
+    else
+        return A
+    end
 end
 
 function build_A_aux(
@@ -100,7 +104,7 @@ end
 function build_Aᵀ_aux(
     ::MatrixRepresentation, implicit, prep, x, y, z, c, args...; suggested_backend
 )
-    (; conditions, backends) = implicit
+    (; conditions, linear_solver, backends) = implicit
     (; prep_Aᵀ) = prep
     actual_backend = isnothing(backends) ? suggested_backend : backends.y
     contexts = (Constant(x), Constant(z), map(Constant, args)...)
@@ -110,7 +114,11 @@ function build_Aᵀ_aux(
     else
         Aᵀ = transpose(jacobian(f, prep_Aᵀ, actual_backend, y, contexts...))
     end
-    return factorize(Aᵀ)
+    if linear_solver isa DirectLinearSolver
+        return factorize(Aᵀ)
+    else
+        return Aᵀ
+    end
 end
 
 function build_Aᵀ_aux(

--- a/test/preparation.jl
+++ b/test/preparation.jl
@@ -5,8 +5,11 @@
     using ADTypes
     using ADTypes: ForwardOrReverseMode, ForwardMode, ReverseMode
     using ForwardDiff: ForwardDiff
+    using LinearAlgebra: Factorization, TransposeFactorization
     using Zygote: Zygote
     using Test
+
+    const GenericMatrix = Union{AbstractMatrix,Factorization,TransposeFactorization}
 
     solver(x) = sqrt.(x), nothing
     conditions(x, y, z) = y .^ 2 .- x
@@ -41,8 +44,8 @@
         @test prep.prep_Aᵀ === nothing
         @test prep.prep_B !== nothing
         @test prep.prep_Bᵀ === nothing
-        @test build_A(implicit, prep, x, y, z, c; suggested_backend) isa AbstractMatrix
-        @test build_Aᵀ(implicit, prep, x, y, z, c; suggested_backend) isa AbstractMatrix
+        @test build_A(implicit, prep, x, y, z, c; suggested_backend) isa GenericMatrix
+        @test build_Aᵀ(implicit, prep, x, y, z, c; suggested_backend) isa GenericMatrix
         @test build_B(implicit, prep, x, y, z, c; suggested_backend) isa JVP
         @test build_Bᵀ(implicit, prep, x, y, z, c; suggested_backend) isa VJP
     end
@@ -53,8 +56,8 @@
         @test prep.prep_Aᵀ !== nothing
         @test prep.prep_B === nothing
         @test prep.prep_Bᵀ !== nothing
-        @test build_A(implicit, prep, x, y, z, c; suggested_backend) isa AbstractMatrix
-        @test build_Aᵀ(implicit, prep, x, y, z, c; suggested_backend) isa AbstractMatrix
+        @test build_A(implicit, prep, x, y, z, c; suggested_backend) isa GenericMatrix
+        @test build_Aᵀ(implicit, prep, x, y, z, c; suggested_backend) isa GenericMatrix
         @test build_B(implicit, prep, x, y, z, c; suggested_backend) isa JVP
         @test build_Bᵀ(implicit, prep, x, y, z, c; suggested_backend) isa VJP
     end


### PR DESCRIPTION
- Only return `factorize(A)` if the linear solver is direct, otherwise keep the matrix itself because we will only need products